### PR TITLE
Blogpost drafting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 
 instance/
+migrations/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+alembic==1.9.2
 blinker==1.5
 cachelib==0.9.0
 click==8.1.3
@@ -7,12 +8,14 @@ Flask-Blogging==2.0.0.post2
 Flask-Caching==2.0.1
 Flask-FileUpload==0.5.0
 Flask-Login==0.6.2
+Flask-Migrate==4.0.2
 Flask-Principal==0.4.0
 Flask-SQLAlchemy==3.0.2
 Flask-WTF==1.0.1
 greenlet==2.0.1
 itsdangerous==2.1.2
 Jinja2==3.1.2
+Mako==1.2.4
 Markdown==3.4.1
 MarkupSafe==2.1.1
 Pygments==2.14.0

--- a/website/__init__.py
+++ b/website/__init__.py
@@ -4,8 +4,10 @@ from os import path
 from flask import Flask
 from flask_login import LoginManager
 from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
 
 db = SQLAlchemy()
+migrate = Migrate()
 
 
 def create_app() -> Flask:
@@ -27,6 +29,7 @@ def create_app() -> Flask:
     from .models import User
 
     create_db(app)
+    migrate.init_app(app, db)
 
     login_manager = LoginManager()
     login_manager.login_view = "auth.login"

--- a/website/models.py
+++ b/website/models.py
@@ -22,7 +22,8 @@ class Blogpost(db.Model):
     __bind_key__ = "blog"
     id = db.Column(db.Integer, primary_key=True)
     slug = db.Column(db.String(120), unique=True)
-    title = db.Column(db.String(100))
+    title = db.Column(db.String(100), nullable=False)
     tags = db.Column(db.String(100))
     content = db.Column(db.Text, nullable=False)
-    date_created = db.Column(db.Date, default=func.now())
+    published = db.Column(db.Boolean, index=True)
+    date_created = db.Column(db.Date, default=func.now(), index=True)

--- a/website/static/css/blog.css
+++ b/website/static/css/blog.css
@@ -99,7 +99,7 @@ input[type="submit"] {
   max-width: 650px;
 }
 
-p#post-date {
+p.metainfo {
   text-align: center;
   color: var(--clr-accent-purple);
   font-size: 12px;
@@ -161,7 +161,7 @@ section#blogposts {
   border-color: var(--clr-accent-green);
 }
 
-.blogpost-card p#post-date {
+.blogpost-card p.metainfo {
   grid-area: date;
   text-align: left;
   margin-bottom: 0;

--- a/website/templates/blog/editor.html
+++ b/website/templates/blog/editor.html
@@ -7,7 +7,7 @@
           href="{{ url_for('static', filename='css/blog.css')}}"/>
 {% endblock %}
 {% block content %}
-    <div class="formContainer">
+    <main role="main" class="formContainer">
         <h2 class="section__title">Create blogpost</h2>
         <form class="blog-form" method="post">
             <input type="text"
@@ -26,7 +26,30 @@
                       name="content"
                       placeholder="What's on your mind?"
                       onfocus="this.placeholder=''">{{ blogpost.content }}</textarea>
+            <label for="published">
+                Publish?
+                <input type="checkbox"
+                       name="published"
+                       value="True"
+                       {% if blogpost.published %} checked="checked"{% endif %}/>
+            </label>
             <input type="submit" id="create-post" value="Submit"/>
         </form>
-    </div>
+        <h3>Drafts</h3>
+        <section id="blogposts">
+            {% for blogpost in blogposts[::-1] %}
+                <a href="/blog/post/{{ blogpost.slug }}">
+                    <div class="blogpost-card">
+                        <h3>{{ blogpost.title }}</h3>
+                        <p class="metainfo">{{ blogpost.date_created }}</p>
+                        <div class="card-tags">
+                            {% for tag in blogpost.tags.split(",") %}
+                                <em>{{ tag }}</em>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </a>
+            {% endfor %}
+        </section>
+    </main>
 {% endblock %}

--- a/website/templates/blog/index.html
+++ b/website/templates/blog/index.html
@@ -14,7 +14,7 @@
                 <a href="/blog/post/{{ blogpost.slug }}">
                     <div class="blogpost-card">
                         <h3>{{ blogpost.title }}</h3>
-                        <p id="post-date">{{ blogpost.date_created }}</p>
+                        <p class="metainfo">{{ blogpost.date_created }}</p>
                         <div class="card-tags">
                             {% for tag in blogpost.tags.split(",") %}
                                 <em>{{ tag }}</em>

--- a/website/templates/blog/post.html
+++ b/website/templates/blog/post.html
@@ -13,13 +13,14 @@
     <main role="main">
         <article class="blog-post">
             <header>
+                {% if not blogpost.published %}<p class="metainfo">Draft</p>{% endif %}
                 <h2>{{ blogpost.title }}</h2>
                 <p id="tags">
                     {% for tag in blogpost.tags.split(",") %}
                         <em>{{ tag }}</em>
                     {% endfor %}
                 </p>
-                <p id="post-date">Posted: {{ blogpost.date_created }}</p>
+                <p class="metainfo">Posted: {{ blogpost.date_created }}</p>
             </header>
             <span id="content">{{ blogpost.content |safe }}</span>
         </article>
@@ -31,8 +32,8 @@
             </button>
             <ul class="dropdown-menu">
                 <li>
-                    <a href="/blog/delete/{{ blogpost.id }}" class="dropdown-item">Delete</a>
                     <a href="/blog/editor/{{ blogpost.id }}" class="dropdown-item">Edit</a>
+                    <a href="/blog/delete/{{ blogpost.id }}" class="dropdown-item">Delete</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Blogposts can now be stored as drafts in the editor and published when
they are ready. This is implemented with a checkbox to toggle a database
column between True or False.
The /blog now filters to only published posts and all drafts can be seen
in the editor in a card view.

To ease implementation the flask-migrate tool was added to migrate
existing databases for the future. This allows us to modify the columns
of the SQL tables without having to reset the data.

Squash of the following commits:

feat(blog): drafting system implemented

fix(database): app now able to migrate databases with flask-migrate
