### PR TITLE
Adding mod_wsgi deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           script: |
             cd /var/www/theodorblom.com
             . .venv/bin/activate
-            pip install .
+            pip install '.[deploy]'
 
       - name: Reload apache server
         uses: appleboy/ssh-action@master

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ cython_debug/
 
 ### User Added Ignores ###
 migrations/
+logs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@
     "pytest >= 7.4.4, < 8",
     "pytest-cov >= 4.1.0, < 5",
   ]
+  deploy = [
+    "mod_wsgi >= 5.0.0, < 6",
+  ]
 
 [tool.setuptools.package-data]
   "website.templates" = ["**/**"]

--- a/scripts/wsgi.py
+++ b/scripts/wsgi.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import logging
+from pathlib import Path
+
+from app import create_app
+
+
+def configure_logging():
+    logs_dir = Path.cwd() / "logs"
+
+    if not logs_dir.exists():
+        logs_dir.mkdir(parents=True)
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        filename=f"{logs_dir.absolute()}/default.log",
+        format="%(asctime)s %(message)s",
+    )
+
+
+configure_logging()
+
+application = create_app()


### PR DESCRIPTION
Currently the wsgi deployment is not included in the repo but is only directly setup server-side through apache2.

Here we take a new approach by including mod_wsgi and its scripts in the repo. This gives better control for what should be happening while deployed and not (such as logging).

No new features are added, the script resembles what is happening on the server currently.